### PR TITLE
Port project to work on Replit

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -65,6 +65,12 @@ def send_notifs(chat_id, contents, value):
                 int(chat_id), msg_content, parse_mode="html",
             )
 
+        """ Just a notification to admin to check which notification was makred relevant """
+        if(chat_id == admin):
+            bot.send_message(
+                int(admin), relevance, parse_mode="markdown"
+            )
+
 
 def scheduledjob():
     """ Send new notifications that come on KTU site. \n
@@ -153,6 +159,26 @@ def start_bot(message):
     bot.send_message(
         message.chat.id, "View the complete code at \n\n https://github.com/AJAYK-01/ktu-notifier ", parse_mode="markdown",
     )
+
+
+@bot.message_handler(commands=["broadcast"])
+def admin_msg(message):
+    """ to send service notifications from admin """
+
+    if(message.chat.id == int(admin)):
+        message = message.text.split(" ", 1)[1]
+        for key, value in users().items():
+            chat_id = key
+            """ checking if unsubscribed and send the notification """
+            if value != "F":
+                try:
+                    bot.send_message(int(chat_id), message,
+                                     parse_mode="markdown")
+                except Exception as e:
+                    print('line 86'+str(e))
+    else:
+        bot.send_message(message.chat.id, "**Uff hAcKerMAn**",
+                         parse_mode="markdown")
 
 
 def ping_repl():

--- a/bot.py
+++ b/bot.py
@@ -198,4 +198,4 @@ scheduler.add_job(ping_repl, 'interval', seconds=20)
 scheduler.start()
 
 # infinity_polling to prevent timeout to telegram api
-bot.infinity_polling(True)
+bot.polling(none_stop=True, timeout=60)

--- a/bot.py
+++ b/bot.py
@@ -183,7 +183,8 @@ def admin_msg(message):
 
 def ping_repl():
     """ ping flask server in replit to avoid sleeping of the bot """
-    repl_res = requests.get("https://ktu-notif.telegramgdrive.repl.co")
+    repl_res = requests.get(
+        f"https://${os.environ['REPL_SLUG']}.${os.environ['REPL_OWNER']}.repl.co")
     print(str(repl_res))
 
 

--- a/bot.py
+++ b/bot.py
@@ -184,7 +184,7 @@ def admin_msg(message):
 def ping_repl():
     """ ping flask server in replit to avoid sleeping of the bot """
     repl_res = requests.get(
-        f"https://${os.environ['REPL_SLUG']}.${os.environ['REPL_OWNER']}.repl.co")
+        f"https://{os.environ['REPL_SLUG']}.{os.environ['REPL_OWNER']}.repl.co")
     print(str(repl_res))
 
 

--- a/bot.py
+++ b/bot.py
@@ -61,9 +61,13 @@ def send_notifs(chat_id, contents, value):
                 msg_link_text = "<a href=\"" + \
                     link["url"]+"\">"+link["text"]+"</a>"
                 msg_content += "\n"+msg_link_text
-            bot.send_message(
-                int(chat_id), msg_content, parse_mode="html",
-            )
+
+            try:
+                bot.send_message(
+                    int(chat_id), msg_content, parse_mode="html",
+                )
+            except Exception as e:
+                print(str(e))
 
         """ Just a notification to admin to check which notification was makred relevant """
         if(chat_id == admin):

--- a/db.py
+++ b/db.py
@@ -1,29 +1,31 @@
 from firebase import Firebase
-from decouple import config
+# from decouple import config
+import os
 
 config = {
-  "apiKey": config('APIKEY'),
-  "authDomain": config('AUTHDOMAIN'),
-  "databaseURL": config('DATABASEURL'),
-  "projectId": config('PROJECTID'),
-  "storageBucket": config('STORAGEBUCKET')
+    "apiKey": os.environ['APIKEY'],
+    "authDomain": os.environ['AUTHDOMAIN'],
+    "databaseURL": os.environ['DATABASEURL'],
+    "projectId": os.environ['PROJECTID'],
+    "storageBucket": os.environ['STORAGEBUCKET']
 }
 
 firebase = Firebase(config)
 
 db = firebase.database()
 
+
 def getData():
-    """ Returns the scraped notifications from the Firebase Database as dictionary """
     data = []
     notifs = db.child("notifs").get().val()
     for notif in notifs:
         data.append(notif)
     return data
 
+
 def setData(data):
-    """ Updates the notifications Firebase DB with the new notifications """
     db.child("notifs").set(data)
+
 
 def users():
     """ Gathers the list of Users from the Firebase Database as a dictionary"""
@@ -31,13 +33,16 @@ def users():
     users = db.child("subs").get()
     return dict(users.val())
 
+
 def subscribe(chat_id):
     """ Adds the user as a Subscriber in the Firebase Database """
     db.child("subs").child(str(chat_id)).set("T")
 
+
 def relevantsub(chat_id):
     """ Adds the user as subscriber of Relevant notifications in the Firebase Database """
     db.child("subs").child(str(chat_id)).set("R")
+
 
 def unsubscribe(chat_id):
     """ Sets the Subscription status of user to False in the Firebase Database """

--- a/main.py
+++ b/main.py
@@ -4,22 +4,40 @@ import shlex
 from flask import Flask
 app = Flask('app')
 
-# Checks for and Kills any duplicate instances of bot running
-cmd1 = subprocess.Popen(["pgrep", "-f", "bot.py"], stdout=subprocess.PIPE)
-cmd2 = subprocess.run(['xargs', 'kill'], stdin=cmd1.stdout)
 
-print(str(cmd2))
+def restart():
+    try:
+        # Checks for and Kills any duplicate instances of bot running
+        cmd1 = subprocess.Popen(
+            ["pgrep", "-f", "bot.py"], stdout=subprocess.PIPE)
+        cmd2 = subprocess.run(['xargs', 'kill'], stdin=cmd1.stdout)
 
-# Spawns an instance of the bot as a subprocess
-cmd = "python bot.py"
-cmds = shlex.split(cmd)
-p = subprocess.Popen(cmds, start_new_session=True)
-print(str(p))
+        print(str(cmd2))
+
+        # Spawns an instance of the bot as a subprocess
+        cmd = "python bot.py"
+        cmds = shlex.split(cmd)
+        p = subprocess.Popen(cmds, start_new_session=True)
+        print(str(p))
+
+        return 'Restart successful'
+
+    except Exception as e:
+        print('Restart error: ' + str(e))
+        return 'Restart failed'
+
+
+restart()
 
 
 @app.route('/')
 def hello_world():
     return 'Hello, I am flask server for a telegram bot on replit!'
+
+
+@app.route('/restart')
+def restart_bot():
+    return restart()
 
 
 app.run(host='0.0.0.0', port=8080)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,25 @@
+""" Flask server is needed for hosting this bot on replit """
+import subprocess
+import shlex
+from flask import Flask
+app = Flask('app')
+
+# Checks for and Kills any duplicate instances of bot running
+cmd1 = subprocess.Popen(["pgrep", "-f", "bot.py"], stdout=subprocess.PIPE)
+cmd2 = subprocess.run(['xargs', 'kill'], stdin=cmd1.stdout)
+
+print(str(cmd2))
+
+# Spawns an instance of the bot as a subprocess
+cmd = "python bot.py"
+cmds = shlex.split(cmd)
+p = subprocess.Popen(cmds, start_new_session=True)
+print(str(p))
+
+
+@app.route('/')
+def hello_world():
+    return 'Hello, I am flask server for a telegram bot on replit!'
+
+
+app.run(host='0.0.0.0', port=8080)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 beautifulsoup4
+flask
+telebot
 requests
 html5lib
 pyTelegramBotAPI
@@ -11,8 +13,9 @@ sseclient
 pycrypto
 requests-toolbelt
 numpy==1.19.1
-tensorflow==2.0.0
+tensorflow-cpu==2.2.0
 h5py==2.9.0
 nltk==3.5
 sklearn
 pickle5
+protobuf==3.20.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pycrypto
 requests-toolbelt
 numpy==1.19.1
 tensorflow-cpu==2.2.0
-h5py==2.9.0
+h5py==2.10.0
 nltk==3.5
 sklearn
 pickle5


### PR DESCRIPTION
## Problem
- Since Heroku is [removing Free Dyno hour plans](https://help.heroku.com/RSBRUH58/removal-of-heroku-free-product-plans-faq), the bot has to be ported to a new platform to continue functioning.
- [Replit](https://replit.com/) has been chosen as it has good free plan and no restrictions on how many hours a month it can run.

## Changes
- Python version available on Replit is 3.8, so a few packages had to be updated to work with it
- ```tensorflow``` has been changed to ```tensorflow-cpu``` to support the lower resources on replit. Although this change doesn't have any other effect on the app as Heroku didn't have a gpu anyway
- Added a flask server, as Replit apps need a web server.
- Added code to keep the repl alive without app sleep. To do this, bot and flask app are kept as two running processes, where the flask app spawns a bot instance (also kills any possible duplicate instances) and the bot pings the flask server every 20 seconds to keep it alive.
- Some admin functions have been added to facilitate broadcasting service messages and also let me know about which messages have been marked irrelevant.